### PR TITLE
Add Terraform backend setup with Azure Storage Account and automated backend.tf generation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ linuxkey.pem
 
 # Terraformer
 generated/
+
+# Ignore backend for tfstate in remote storage
+backend.tf

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository has been crated to study terraform by the help of [Azure Infrast
 ## Create a credentials.tfvars file in the root of the project
 
 Content of the `credentials.tfvars` file:
-```
+```bash
 subscription_id = "<AZURE_SUBSCRIPTION_ID>"     # Your Azure Subscription ID
 client_id       = "<AZURE_ENTRA_APP_CLIENT_ID>" # Select your registered app's get its Client ID
 client_secret   = "<AZURE_ENTRA_APP_SECRET"     # Select your registered app's Client credentials
@@ -27,23 +27,46 @@ tenant_id       = "<AZURE_ENTRA_APP_TENANT_ID"  # Select your registered app's D
 
 ## Terraform commands
 
-### Take control on existing infrastructure
-
-Terraform import maps existing infrastructure (like a resource in Azure, AWS, etc.) to a resource block in your Terraform configuration, so Terraform can manage it going forward. It doesn’t create anything — it just links what's already there to your code.
-
-```powershell
-terraform import -var-file="credentials.tfvars" -input=false module.${MODULE}}$.azurerm_resource_group.app_grp "/subscriptions/${ARM_SUBSCRIPTION_ID}/resourceGroups/rg-${MODULE}}"
-```
-
 ### Initialize project
 
-```powershell
+```bash
 terraform init
+```
+
+### Create backend infrastructure
+
+Before you can use the modules, you need to create the backend infrastructure.
+<br>The backend infrastructure is managed by the `infra/backend` module.
+
+This process is automated by the `scripts/backend.sh` script.
+
+The script will:
+1. Create the backend infrastructure using the `infra/backend` module -> will create a storage account with a random name.
+2. Generate the `backend.tf` file in the root of the project with the correct `storage_account_name`.
+
+To run the script:
+```bash
+bash scripts/backend.sh
+```
+
+After running the script, you can initialize the main project:
+```bash
+terraform init
+```
+
+### Destroy backend infrastructure
+
+To destroy the backend infrastructure run the script with the `destroy` argument:
+
+```bash
+bash scripts/backend.sh destroy
 ```
 
 ### Nginx deployed by Cloud Init
 
-```powershell
+**Note:** Before deploying this module, make sure you have created the backend infrastructure as described above.
+
+```bash
 # Check changes
 terraform plan -var-file="credentials.tfvars" -target="module.cloud-init-nginx" -out="cloud-init-nginx.tfplan"
 
@@ -63,7 +86,9 @@ terraform destroy -var-file="credentials.tfvars" -target="module.cloud-init-ngin
 
 ### Key Vault
 
-```powershell
+**Note:** Before deploying this module, make sure you have created the backend infrastructure as described above.
+
+```bash
 # Check changes
 terraform plan -var-file="credentials.tfvars" -target="module.keyvault" -out="keyvault.tfplan"
 
@@ -85,7 +110,9 @@ terraform destroy -var-file="credentials.tfvars" -target="module.keyvault" -auto
 
 ### Monitor
 
-```powershell
+**Note:** Before deploying this module, make sure you have created the backend infrastructure as described above.
+
+```bash
 # Check changes
 terraform plan -var-file="credentials.tfvars" -target="module.monitor" -out="monitor.tfplan"
 
@@ -105,7 +132,9 @@ terraform destroy -var-file="credentials.tfvars" -target="module.monitor" -auto-
 
 ### SQL
 
-```powershell
+**Note:** Before deploying this module, make sure you have created the backend infrastructure as described above.
+
+```bash
 # Check changes
 terraform plan -var-file="credentials.tfvars" -target="module.sql" -out="sql.tfplan"
 
@@ -126,7 +155,9 @@ terraform destroy -var-file="credentials.tfvars" -target="module.sql" -auto-appr
 
 ### Storage Account
 
-```powershell
+**Note:** Before deploying this module, make sure you have created the backend infrastructure as described above.
+
+```bash
 # Check changes
 terraform plan -var-file="credentials.tfvars" -target="module.storage" -out="storage.tfplan"
 
@@ -145,7 +176,9 @@ terraform destroy -var-file="credentials.tfvars" -target="module.storage" -auto-
 
 ### Linux VM
 
-```powershell
+**Note:** Before deploying this module, make sure you have created the backend infrastructure as described above.
+
+```bash
 # Check changes
 terraform plan -var-file="credentials.tfvars" -target="module.vm-linux" -out="vm-linux.tfplan"
 
@@ -164,7 +197,9 @@ terraform destroy -var-file="credentials.tfvars" -target="module.vm-linux" -auto
 
 ### Windows VM
 
-```powershell
+**Note:** Before deploying this module, make sure you have created the backend infrastructure as described above.
+
+```bash
 # Check changes
 terraform plan -var-file="credentials.tfvars" -target="module.vm-win" -out="vm-win.tfplan"
 
@@ -186,7 +221,9 @@ terraform destroy -var-file="credentials.tfvars" -target="module.vm-win" -auto-a
 
 ### Vnet
 
-```powershell
+**Note:** Before deploying this module, make sure you have created the backend infrastructure as described above.
+
+```bash
 # Check changes
 terraform plan -var-file="credentials.tfvars" -target="module.vnet" -out="vnet.tfplan"
 
@@ -206,7 +243,9 @@ terraform destroy -var-file="credentials.tfvars" -target="module.vnet" -auto-app
 
 ### WebApp
 
-```powershell
+**Note:** Before deploying this module, make sure you have created the backend infrastructure as described above.
+
+```bash
 # Check changes
 terraform plan -var-file="credentials.tfvars" -target="module.webapp" -out="webapp.tfplan"
 
@@ -226,6 +265,14 @@ terraform destroy -var-file="credentials.tfvars" -target="module.webapp" -auto-a
 ```
 
 # HOWTOs
+
+## Take control on existing infrastructure
+
+Terraform import maps existing infrastructure (like a resource in Azure, AWS, etc.) to a resource block in your Terraform configuration, so Terraform can manage it going forward. It doesn’t create anything — it just links what's already there to your code.
+
+```bash
+terraform import -var-file="credentials.tfvars" -input=false module.${MODULE}}$.azurerm_resource_group.app_grp "/subscriptions/${ARM_SUBSCRIPTION_ID}/resourceGroups/rg-${MODULE}}"
+```
 
 ## App registrations
 

--- a/infra/backend/main.tf
+++ b/infra/backend/main.tf
@@ -1,0 +1,28 @@
+resource "random_string" "random" {
+  length  = 6
+  special = false
+  upper   = false
+}
+
+resource "azurerm_resource_group" "rg" {
+  name     = "rg-terraform-backend"
+  location = "westeurope"
+}
+
+resource "azurerm_storage_account" "sa" {
+  name                     = "tfbackendstorage${random_string.random.result}"
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = azurerm_resource_group.rg.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  lifecycle {
+    ignore_changes = [name]
+  }
+}
+
+resource "azurerm_storage_container" "container" {
+  name                  = "tfstate"
+  storage_account_name  = azurerm_storage_account.sa.name
+  container_access_type = "private"
+}

--- a/infra/backend/output.tf
+++ b/infra/backend/output.tf
@@ -1,0 +1,3 @@
+output "storage_account_name" {
+  value = azurerm_storage_account.sa.name
+}

--- a/infra/backend/providers.tf
+++ b/infra/backend/providers.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "4.37.0"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+  subscription_id = var.subscription_id
+  tenant_id       = var.tenant_id
+  client_id       = var.client_id
+  client_secret   = var.client_secret
+}

--- a/infra/backend/variables.tf
+++ b/infra/backend/variables.tf
@@ -1,0 +1,16 @@
+variable "subscription_id" {
+  type = string
+}
+
+variable "tenant_id" {
+  type = string
+}
+
+variable "client_id" {
+  type = string
+}
+
+variable "client_secret" {
+  type      = string
+  sensitive = true
+}

--- a/modules/cloud-init-nginx/README.md
+++ b/modules/cloud-init-nginx/README.md
@@ -1,0 +1,8 @@
+### Backend Configuration
+
+- The backend configuration is located in the project root folder (`backend.tf`)
+- The `terraform init` command must be run in the root folder
+
+### Backend Infrastructure Creation with Terraform
+
+- The `infra/backend` module creates the necessary Azure Storage Account

--- a/modules/cloud-init-nginx/variables.tf
+++ b/modules/cloud-init-nginx/variables.tf
@@ -1,10 +1,9 @@
 locals {
-  raw_ts       = timestamp()
-  short_ts     = formatdate("YYMMDDhhmm", local.raw_ts)
-  module_path  = path.module
-  rg_name      = "rg-${basename(local.module_path)}"
-  location     = "West Europe"
-  storage_name = "tformstore${local.short_ts}"
+  raw_ts      = timestamp()
+  short_ts    = formatdate("YYMMDDhhmm", local.raw_ts)
+  module_path = path.module
+  rg_name     = "rg-${basename(local.module_path)}"
+  location    = "West Europe"
 }
 
 data "template_cloudinit_config" "linuxconfig" {

--- a/modules/keyvault/README.md
+++ b/modules/keyvault/README.md
@@ -1,0 +1,8 @@
+### Backend Configuration
+
+- The backend configuration is located in the project root folder (`backend.tf`)
+- The `terraform init` command must be run in the root folder
+
+### Backend Infrastructure Creation with Terraform
+
+- The `infra/backend` module creates the necessary Azure Storage Account

--- a/modules/keyvault/main.tf
+++ b/modules/keyvault/main.tf
@@ -137,6 +137,9 @@ resource "azurerm_key_vault" "app_vault" {
   depends_on = [
     azurerm_resource_group.app_grp
   ]
+  lifecycle {
+    ignore_changes = [name]
+  }
 }
 
 resource "azurerm_key_vault_secret" "vmpassword" {

--- a/modules/keyvault/variables.tf
+++ b/modules/keyvault/variables.tf
@@ -4,7 +4,6 @@ locals {
   module_path   = path.module
   rg_name       = "rg-${basename(local.module_path)}"
   location      = "West Europe"
-  storage_name  = "tformstore${local.short_ts}"
   keyvault_name = "keyvault${local.short_ts}"
 }
 

--- a/modules/monitor/README.md
+++ b/modules/monitor/README.md
@@ -1,0 +1,8 @@
+### Backend Configuration
+
+- The backend configuration is located in the project root folder (`backend.tf`)
+- The `terraform init` command must be run in the root folder
+
+### Backend Infrastructure Creation with Terraform
+
+- The `infra/backend` module creates the necessary Azure Storage Account

--- a/modules/monitor/main.tf
+++ b/modules/monitor/main.tf
@@ -50,6 +50,10 @@ resource "azurerm_public_ip" "public_ip" {
   domain_name_label   = local.domain_name_label
 
   depends_on = [azurerm_resource_group.app_grp]
+
+  lifecycle {
+    ignore_changes = [domain_name_label]
+  }
 }
 
 resource "azurerm_network_security_group" "nsg" {

--- a/modules/monitor/resources/monitor-setup.sh
+++ b/modules/monitor/resources/monitor-setup.sh
@@ -145,7 +145,7 @@ function installServices {
     echo "  - to: ${basePath}..."
     sudo rm -f monitor-v*.zip 2>&1 || true
     sudo wget -q --show-progress "$url"
-
+    
     echo "- [2./${totalSteps}.] Unzip monitor-v*.zip to ${basePath}..."
     sudo unzip -q -o monitor-v*.zip -d monitor
     sudo cp ${cfgBackupPath}/*.yaml ${monitorPath}/configs >/dev/null 2>&1 || true
@@ -162,10 +162,10 @@ function installServices {
     
     echo "- [5./${totalSteps}.] Save your credentials"
     echo -n "${VM_USER}:${VM_PASS}" \
-        | base64 \
-        | sudo tee ${monitorPath}/configs/auth.db > /dev/null \
-        && sudo chmod 600 ${monitorPath}/configs/auth.db \
-        && sudo chown root:root ${monitorPath}/configs/auth.db
+    | base64 \
+    | sudo tee ${monitorPath}/configs/auth.db > /dev/null \
+    && sudo chmod 600 ${monitorPath}/configs/auth.db \
+    && sudo chown root:root ${monitorPath}/configs/auth.db
     
     echo "- [6./${totalSteps}.] Copy ${programDir}/tools/*.service to /etc/systemd/system..."
     sudo cp tools/*.service /etc/systemd/system

--- a/modules/sql/README.md
+++ b/modules/sql/README.md
@@ -1,0 +1,8 @@
+### Backend Configuration
+
+- The backend configuration is located in the project root folder (`backend.tf`)
+- The `terraform init` command must be run in the root folder
+
+### Backend Infrastructure Creation with Terraform
+
+- The `infra/backend` module creates the necessary Azure Storage Account

--- a/modules/sql/main.tf
+++ b/modules/sql/main.tf
@@ -10,6 +10,10 @@ resource "azurerm_mssql_server" "appserver" {
   version                      = "12.0"
   administrator_login          = "sqladmin"
   administrator_login_password = "pass@123"
+
+  lifecycle {
+    ignore_changes = [name]
+  }
 }
 
 resource "azurerm_mssql_database" "appdb" {

--- a/modules/storage/README.md
+++ b/modules/storage/README.md
@@ -1,0 +1,8 @@
+### Backend Configuration
+
+- The backend configuration is located in the project root folder (`backend.tf`)
+- The `terraform init` command must be run in the root folder
+
+### Backend Infrastructure Creation with Terraform
+
+- The `infra/backend` module creates the necessary Azure Storage Account

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -14,6 +14,10 @@ resource "azurerm_storage_account" "storage_account" {
     purpose     = "learning"
     environment = "dev"
   }
+
+  lifecycle {
+    ignore_changes = [name]
+  }
 }
 
 resource "azurerm_storage_container" "data" {

--- a/modules/vm-linux/README.md
+++ b/modules/vm-linux/README.md
@@ -1,0 +1,8 @@
+### Backend Configuration
+
+- The backend configuration is located in the project root folder (`backend.tf`)
+- The `terraform init` command must be run in the root folder
+
+### Backend Infrastructure Creation with Terraform
+
+- The `infra/backend` module creates the necessary Azure Storage Account

--- a/modules/vm-linux/variables.tf
+++ b/modules/vm-linux/variables.tf
@@ -1,7 +1,6 @@
 locals {
-  raw_ts       = timestamp()
-  short_ts     = formatdate("YYMMDDhhmm", local.raw_ts)
-  rg_name      = "rg-vm-linux"
-  location     = "West Europe"
-  storage_name = "tformstore${local.short_ts}"
+  raw_ts   = timestamp()
+  short_ts = formatdate("YYMMDDhhmm", local.raw_ts)
+  rg_name  = "rg-vm-linux"
+  location = "West Europe"
 }

--- a/modules/vm-win/README.md
+++ b/modules/vm-win/README.md
@@ -1,0 +1,8 @@
+### Backend Configuration
+
+- The backend configuration is located in the project root folder (`backend.tf`)
+- The `terraform init` command must be run in the root folder
+
+### Backend Infrastructure Creation with Terraform
+
+- The `infra/backend` module creates the necessary Azure Storage Account

--- a/modules/vm-win/main.tf
+++ b/modules/vm-win/main.tf
@@ -159,6 +159,10 @@ resource "azurerm_storage_account" "appstore" {
   }
 
   depends_on = [azurerm_resource_group.app_grp]
+
+  lifecycle {
+    ignore_changes = [name]
+  }
 }
 
 resource "azurerm_storage_container" "data" {

--- a/modules/vnet/README.md
+++ b/modules/vnet/README.md
@@ -1,0 +1,8 @@
+### Backend Configuration
+
+- The backend configuration is located in the project root folder (`backend.tf`)
+- The `terraform init` command must be run in the root folder
+
+### Backend Infrastructure Creation with Terraform
+
+- The `infra/backend` module creates the necessary Azure Storage Account

--- a/modules/webapp/README.md
+++ b/modules/webapp/README.md
@@ -1,0 +1,8 @@
+### Backend Configuration
+
+- The backend configuration is located in the project root folder (`backend.tf`)
+- The `terraform init` command must be run in the root folder
+
+### Backend Infrastructure Creation with Terraform
+
+- The `infra/backend` module creates the necessary Azure Storage Account

--- a/modules/webapp/main.tf
+++ b/modules/webapp/main.tf
@@ -9,6 +9,10 @@ resource "azurerm_service_plan" "webapp_plan" {
   location            = azurerm_resource_group.app_grp.location
   os_type             = "Linux"
   sku_name            = "F1"
+
+  lifecycle {
+    ignore_changes = [name]
+  }
 }
 
 resource "azurerm_linux_web_app" "webapp" {
@@ -21,6 +25,10 @@ resource "azurerm_linux_web_app" "webapp" {
     application_stack {
       dotnet_version = "8.0"
     }
+  }
+
+  lifecycle {
+    ignore_changes = [name]
   }
 }
 

--- a/provider.tf
+++ b/provider.tf
@@ -1,11 +1,4 @@
-terraform {
-  required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "4.37.0"
-    }
-  }
-}
+
 
 provider "azurerm" {
   subscription_id = var.subscription_id

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "4.37.0"
+    }
+  }
+}

--- a/scripts/backend.sh
+++ b/scripts/backend.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Define paths
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+BACKEND_DIR="$ROOT_DIR/infra/backend"
+TFVARS_FILE="$ROOT_DIR/credentials.tfvars"
+BACKEND_TF="$ROOT_DIR/backend.tf"
+
+# Logging helpers
+log_info() {
+    echo -e "\033[1;34m[INFO]\033[0m $1"
+}
+
+log_error() {
+    echo -e "\033[1;31m[ERROR]\033[0m $1"
+}
+
+# Exit with error message
+exit_with_error() {
+    log_error "$1"
+    exit 1
+}
+
+# Initialize Terraform backend module
+initialize_backend() {
+    log_info "Initializing Terraform backend module..."
+    terraform -chdir="$BACKEND_DIR" init -upgrade
+}
+
+# Apply backend infrastructure
+apply_backend() {
+    log_info "Applying backend infrastructure..."
+    if [ ! -f "$TFVARS_FILE" ]; then
+        exit_with_error "Missing credentials file: $TFVARS_FILE"
+    fi
+    terraform -chdir="$BACKEND_DIR" apply -var-file="$TFVARS_FILE" -auto-approve
+}
+
+# Destroy backend infrastructure
+destroy_backend() {
+    log_info "Destroying backend infrastructure..."
+    if [ ! -f "$TFVARS_FILE" ]; then
+        exit_with_error "Missing credentials file: $TFVARS_FILE"
+    fi
+    terraform -chdir="$BACKEND_DIR" destroy -var-file="$TFVARS_FILE" -auto-approve
+    
+    if [ -f "$BACKEND_TF" ]; then
+        log_info "Removing backend.tf..."
+        rm -f "$BACKEND_TF"
+    fi
+    
+    log_info "Backend infrastructure destroyed and backend.tf removed."
+}
+
+# Retrieve storage account name from Terraform output
+get_storage_account_name() {
+    terraform -chdir="$BACKEND_DIR" output -raw storage_account_name || exit_with_error "Output 'storage_account_name' is empty or unavailable."
+}
+
+# Generate backend.tf file in project root
+generate_backend_tf() {
+    local storage_account_name
+    
+    log_info "Retrieving storage account name..."
+    storage_account_name=$(get_storage_account_name)
+    
+    log_info "Generating backend.tf with storage account: $storage_account_name"
+    cat <<EOF > "$BACKEND_TF"
+terraform {
+  backend "azurerm" {
+    resource_group_name  = "rg-terraform-backend"
+    storage_account_name = "$storage_account_name"
+    container_name       = "tfstate"
+    key                  = "terraform.tfstate"
+  }
+}
+EOF
+}
+
+# Main execution flow
+main() {
+    if [[ "${1:-}" == "destroy" ]]; then
+        initialize_backend
+        destroy_backend
+    else
+        initialize_backend
+        apply_backend
+        generate_backend_tf
+        log_info "Done: backend.tf created at $BACKEND_TF"
+    fi
+}
+
+main "$@"

--- a/variables.tf
+++ b/variables.tf
@@ -18,3 +18,9 @@ variable "tenant_id" {
   type        = string
   description = "Azure Tenant ID"
 }
+
+variable "storage_account_name" {
+  type        = string
+  description = "The name of the storage account for the backend."
+  default     = "tfbackendstorage"
+}


### PR DESCRIPTION
This PR introduces the Terraform backend infrastructure setup to the project, focusing on creating a dedicated Azure Storage Account and container to securely store Terraform state files remotely.

Key changes include:
- New `infra/backend` module to deploy Azure resource group, storage account with a random suffix, and blob container for state.
- A comprehensive helper script (`scripts/backend.sh`) automates backend module initialization, applying infrastructure, generating `backend.tf` in project root, and destruction.
- Updated README.md and module README files with instructions on backend initialization and usage.
- Removal of `terraform` block from `provider.tf` and centralized backend config in a dedicated `backend.tf`.
- Additions of variables and providers required for backend module with proper secrets handling.
- Git clean-up rules for `.terraform` directory and backend files.

This change establishes a robust, reusable, and reproducible backend infrastructure pattern for Terraform state, essential for collaboration and CI/CD integration. Please review and approve the backend integration flow and scripts.

***

Would you like me to help draft a reviewer checklist or testing notes for this PR?